### PR TITLE
Add documentation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
+[![GoDoc](https://godoc.org/github.com/bradylove/envstruct?status.png)](https://godoc.org/github.com/bradylove/envstruct)
+
 # envstruct
 
 envstruct is a simple library for populating values on structs from environment
 variables.
-
-## Documentation
-
-[https://godoc.org/github.com/bradylove/envstruct](https://godoc.org/github.com/bradylove/envstruct)
 
 ## Usage
 


### PR DESCRIPTION
The Documentation section can be replaced with a simpler docs badge from godoc.org.

Signed-off-by: Jeremy Alvis jalvis@pivotal.io
